### PR TITLE
Only include active languages for cms, categories and tags

### DIFF
--- a/src/Entity/Config.php
+++ b/src/Entity/Config.php
@@ -7,6 +7,9 @@ class Config
 
     private $filepath;
     private $filename;
+    private $shopUrl;
+    private $sLangQuery;
+
 
     /**
      * Config constructor.
@@ -17,7 +20,46 @@ class Config
     {
         $this->filepath = $filepath;
         $this->filename = $filename;
+
+        $aLangParams    = \oxRegistry::getConfig()->getConfigParam('aLanguageParams');
+        $aActiveLangIds = array();
+
+        foreach ($aLangParams as $key=>$lang) {
+            if ($lang['active']) {
+                $aActiveLangIds[] = $lang['baseId'];
+            }
+        }
+
+        if ($aActiveLangIds && count($aActiveLangIds) > 0) {
+            $this->sLangQuery = ' AND OXLANG IN (' . implode(',', $aActiveLangIds) . ')';
+        }
     }
+
+    /**
+     * @return mixed
+     */
+    public function getShopUrl()
+    {
+        return $this->shopUrl;
+    }
+
+    /**
+     * @param mixed $shopUrl
+     */
+    public function setShopUrl($shopUrl)
+    {
+        $this->shopUrl = $shopUrl;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLangQuery()
+    {
+        return $this->sLangQuery;
+    }
+
 
     /**
      * @return mixed

--- a/src/Query/AbstractQuery.php
+++ b/src/Query/AbstractQuery.php
@@ -2,6 +2,7 @@
 
 namespace Ivoba\OxidSiteMap\Query;
 
+use Ivoba\OxidSiteMap\Entity\Config;
 use Ivoba\OxidSiteMap\Entity\Page;
 
 abstract class AbstractQuery implements QueryInterface
@@ -11,6 +12,7 @@ abstract class AbstractQuery implements QueryInterface
     protected $siteUrl;
     protected $hierachy;
     protected $changefreq;
+    protected $config;
 
     abstract public function getSql();
 
@@ -20,10 +22,10 @@ abstract class AbstractQuery implements QueryInterface
      * @param $hierachy
      * @param $changefreq
      */
-    public function __construct(\oxLegacyDb $db, $siteUrl, $hierachy, $changefreq)
+    public function __construct(\oxLegacyDb $db, Config $config, $hierachy, $changefreq)
     {
         $this->db = $db;
-        $this->siteUrl = $siteUrl;
+        $this->config = $config;
         $this->hierachy = $hierachy;
         $this->changefreq = $changefreq;
     }
@@ -51,7 +53,7 @@ abstract class AbstractQuery implements QueryInterface
         }
 
         return new Page(
-            $this->siteUrl.'/'.$url,
+            $this->config->getShopUrl().'/'.$url,
             $this->hierachy,
             date('Y').'-'.date('m').'-'.date('d').'T'.date('h').':'.date('i').':'.date('s').'+00:00',
             $this->changefreq

--- a/src/Query/Categories.php
+++ b/src/Query/Categories.php
@@ -23,7 +23,7 @@ class Categories extends AbstractQuery
                       (oxseo.OXOBJECTID = oxcategories.OXID)
                     WHERE
                         oxactive = 1 AND
-                        oxhidden = 0
+                        oxhidden = 0 %s
                     ORDER by oxtitle ASC";
 
 
@@ -32,6 +32,7 @@ class Categories extends AbstractQuery
      */
     public function getSql()
     {
+        $this->sql = sprintf($this->sql, $this->config->getLangQuery());
         return $this->sql;
     }
 

--- a/src/Query/Cms.php
+++ b/src/Query/Cms.php
@@ -9,7 +9,6 @@ namespace Ivoba\OxidSiteMap\Query;
 class Cms extends AbstractQuery
 {
     /**
-     * @todo multilang AND oxseo.oxlang  = '0'
      * @var string
      */
     private $sql = "SELECT oxid,oxtitle,oxstdurl,oxseourl FROM oxcontents
@@ -18,7 +17,7 @@ class Cms extends AbstractQuery
                     ON
                       (oxseo.OXOBJECTID = oxcontents.OXID)
                     WHERE oxactive = 1 AND
-                          oxfolder = 'CMSFOLDER_USERINFO'
+                          oxfolder = 'CMSFOLDER_USERINFO' %s
                     ORDER by oxtitle ASC";
 
 
@@ -27,6 +26,7 @@ class Cms extends AbstractQuery
      */
     public function getSql()
     {
+        $this->sql = sprintf($this->sql, $this->config->getLangQuery());
         return $this->sql;
     }
 

--- a/src/Query/Tags.php
+++ b/src/Query/Tags.php
@@ -14,10 +14,9 @@ class Tags extends AbstractQuery
                         oxseo seo
                     WHERE
                         seo.oxseourl <> '' AND
-                        seo.oxstdurl LIKE '%=tag%' AND
+                        seo.oxstdurl LIKE '%%=tag%%' AND
                         seo.oxtype='dynamic' AND
-                        seo.oxexpired = 0 AND
-                        seo.oxlang = 0";
+                        seo.oxexpired = 0 %s";
 
 
     /**
@@ -25,6 +24,7 @@ class Tags extends AbstractQuery
      */
     public function getSql()
     {
+        $this->sql = sprintf($this->sql, $this->config->getLangQuery());
         return $this->sql;
     }
 


### PR DESCRIPTION
With this PR SEO URLs of inactive languages will no longer appear in the sitemap, at least for categories, cms pages and tags. Products will still return the base link.